### PR TITLE
Add JIRA related terms for `Feature` and 'Scenario`

### DIFF
--- a/gherkin-languages.json
+++ b/gherkin-languages.json
@@ -638,12 +638,15 @@
     ],
     "examples": [
       "Examples",
-      "Scenarios"
+      "Scenarios",
+      "Stories",
+      "User Stories"
     ],
     "feature": [
       "Feature",
       "Business Need",
-      "Ability"
+      "Ability",
+      "Epic"
     ],
     "given": [
       "* ",
@@ -652,7 +655,9 @@
     "name": "English",
     "native": "English",
     "scenario": [
-      "Scenario"
+      "Scenario",
+      "Story",
+      "User Story"
     ],
     "scenarioOutline": [
       "Scenario Outline",


### PR DESCRIPTION
Our customer uses JIRA (https://www.atlassian.com/software/jira). This tool uses different wording for `Feature` and `Scenario`. To avoid confusion when he reads and writes .FEATURE-files, Jira terming is added to `gherkin-languages.json`.